### PR TITLE
Límite de acceso

### DIFF
--- a/Manejador.rb
+++ b/Manejador.rb
@@ -78,21 +78,26 @@ class Manejador
 			|proceso|
 			if proceso.id == idProceso
 				procesoExiste = true
-				proceso.tablaPaginas.each do
-					|item2|
-					if numMarco == Integer(direccion).fdiv(memReal.tamPagina).floor && item2.marcoReal >= 0
-					puts "La instruccion se encuentra cargada en marco real #{item2.marcoReal}, se ha accesado"
-					memReal.arrMarcos[numMarco].fueAccesado = 1
+				if proceso.cantBytes >= Integer(direccion)
+					proceso.tablaPaginas.each do
+						|item2|
+						if numMarco == Integer(direccion).fdiv(memReal.tamPagina).floor && item2.marcoReal >= 0
+						puts "La instruccion se encuentra cargada en marco real #{item2.marcoReal}, se ha accesado"
+						memReal.arrMarcos[numMarco].fueAccesado = 1
+						end
+						if numMarco == Integer(direccion).fdiv(memReal.tamPagina).floor && item2.marcoSwap >= 0
+						puts "La instruccion se encuentra cargada en marco swap #{item2.marcoSwap}, no se ha accesado"
+						puts "Proceso #{idProceso} genera page fault."
+						proceso.faultsCausados = proceso.faultsCausados + 1
+						procesoTemp = self.getProceso(idProceso)
+						procesoTemp.desplegarProceso
+						puts procesoTemp.marcosRealAsig
+						self.asignarMarcoPag(procesoTemp, memReal, memSwap, Integer(direccion).fdiv(memReal.tamPagina).floor)
+						end
+						numMarco = numMarco + 1
 					end
-					if numMarco == Integer(direccion).fdiv(memReal.tamPagina).floor && item2.marcoSwap >= 0
-					puts "La instruccion se encuentra cargada en marco swap #{item2.marcoSwap}, no se ha accesado"
-					puts "Proceso #{idProceso} genera page fault."
-					procesoTemp = self.getProceso(idProceso)
-					procesoTemp.desplegarProceso
-					puts procesoTemp.marcosRealAsig
-					self.asignarMarcoPag(procesoTemp, memReal, memSwap, Integer(direccion).fdiv(memReal.tamPagina).floor)
-					end
-					numMarco = numMarco + 1
+				else
+				puts "La direccion referenciada no es valida para el proceso #{idProceso}"
 				end
 			end
 		end
@@ -160,7 +165,7 @@ class Manejador
 			puts "F2C"
 			marcosNecesitados = cantPideMarcos
 			if self.mandarSwap(proceso, memReal, memSwap, marcosNecesitados)
-				self.asignarMarcos(proceso, memReal, memSwap)
+				self.asignarMarcoPag(proceso, memReal, memSwap, pagina)
 			end
 		end
 	end

--- a/main.rb
+++ b/main.rb
@@ -34,7 +34,7 @@ while !bExit do
 			sleep(1)
 			#No se nos olvide quitar ese sleep porque nos inflaría los benchmarks
 		when 'A'
-			puts "#{arrComando[0].upcase} #{arrComando[1]} #{arrComando[2]} #{arrComando[2]}"
+			puts "#{arrComando[0].upcase} #{arrComando[1]} #{arrComando[2]} #{arrComando[3]}"
 			so.accederProceso(arrComando[1], arrComando[2], arrComando[3], memReal, memSwap)
 		when 'L'
 			puts "#{arrComando[0].upcase} #{arrComando[1]}"


### PR DESCRIPTION
se podía accesar páginas que no eran del proceso si ponías direcciones más grandes que la cantBytes del proceso.
incluye mensaje de error para dirección inválida.
